### PR TITLE
Reuse AddSubmissionFragment in onboarding flow

### DIFF
--- a/app/src/main/java/com/example/qstreak/db/ActivitiesRepository.kt
+++ b/app/src/main/java/com/example/qstreak/db/ActivitiesRepository.kt
@@ -5,11 +5,12 @@ import com.example.qstreak.models.Activity
 import com.example.qstreak.network.QstreakApiService
 
 class ActivitiesRepository(
-    private val activitiesDao: ActivitiesDao
+    private val activitiesDao: ActivitiesDao,
+    private val api: QstreakApiService
 ) {
     val activities: LiveData<List<Activity>> = activitiesDao.getAllActivities()
 
     suspend fun refreshActivities(uid: String) {
-        activitiesDao.insertAllActivities(QstreakApiService.getQstreakApiService().getActivities(uid))
+        activitiesDao.insertAllActivities(api.getActivities(uid))
     }
 }

--- a/app/src/main/java/com/example/qstreak/db/SubmissionRepository.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionRepository.kt
@@ -8,14 +8,13 @@ import com.example.qstreak.network.SubmissionData
 
 class SubmissionRepository(
     private val submissionDao: SubmissionDao,
-    private val submissionWithActivityDao: SubmissionWithActivityDao
+    private val submissionWithActivityDao: SubmissionWithActivityDao,
+    private val api: QstreakApiService
 ) {
     val submissionsWithWithActivities: LiveData<List<SubmissionWithActivities>> =
         submissionWithActivityDao.getSubmissionsWithActivities()
 
     suspend fun insert(submission: Submission, activities: List<Activity>, uid: String) {
-        val api = QstreakApiService.getQstreakApiService()
-
         // TODO convert submission model
         val response = api.createSubmission(
             CreateSubmissionRequest(

--- a/app/src/main/java/com/example/qstreak/db/UserRepository.kt
+++ b/app/src/main/java/com/example/qstreak/db/UserRepository.kt
@@ -5,7 +5,7 @@ import com.example.qstreak.network.Account
 import com.example.qstreak.network.CreateUserRequest
 import com.example.qstreak.network.QstreakApiSignupService
 
-class UserRepository(val userDao: UserDao) {
+class UserRepository(private val userDao: UserDao, private val api: QstreakApiSignupService) {
     suspend fun getUser(): User? = userDao.getUser()
 
     suspend fun createUser(age: Int, householdSize: Int, zip: String): User {

--- a/app/src/main/java/com/example/qstreak/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/example/qstreak/ui/OnboardingActivity.kt
@@ -8,21 +8,19 @@ import kotlinx.android.synthetic.main.activity_onboarding.*
 
 class OnboardingActivity : AppCompatActivity() {
 
-    // TODO handle launching of app when uid is already available
-
     private lateinit var viewPager: ViewPager2
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_onboarding)
 
-        val onboardingAdapter = OnboardingAdapter(this, 2)
+        val onboardingAdapter = OnboardingAdapter(this, 3)
         onboarding_view_pager.adapter = onboardingAdapter
         onboarding_view_pager.isUserInputEnabled = false
         viewPager = onboarding_view_pager
     }
 
-    fun onSetupButtonClicked() {
-        viewPager.setCurrentItem(OnboardingSignupFragment.ONBOARDING_ADAPTER_POSITION, true)
+    fun setCurrentItem(adapterPosition: Int) {
+        viewPager.setCurrentItem(adapterPosition, true)
     }
 }

--- a/app/src/main/java/com/example/qstreak/ui/OnboardingAdapter.kt
+++ b/app/src/main/java/com/example/qstreak/ui/OnboardingAdapter.kt
@@ -13,9 +13,9 @@ class OnboardingAdapter(activity: AppCompatActivity, private val itemsCount: Int
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            // TODO set values to variables named for fragments
             OnboardingLogoFragment.ONBOARDING_ADAPTER_POSITION -> OnboardingLogoFragment()
             OnboardingSignupFragment.ONBOARDING_ADAPTER_POSITION -> OnboardingSignupFragment()
+            OnboardingSubmissionFragment.ONBOARDING_ADAPTER_POSITION -> OnboardingSubmissionFragment()
             else -> OnboardingLogoFragment()
         }
     }

--- a/app/src/main/java/com/example/qstreak/ui/OnboardingLogoFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/OnboardingLogoFragment.kt
@@ -17,10 +17,14 @@ class OnboardingLogoFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_onboarding_logo, container, false)
 
         view.setup_button.setOnClickListener {
-            (activity as OnboardingActivity).onSetupButtonClicked()
+            navigateToSignup()
         }
 
         return view
+    }
+
+    private fun navigateToSignup() {
+        (activity as OnboardingActivity).setCurrentItem(OnboardingSignupFragment.ONBOARDING_ADAPTER_POSITION)
     }
 
     companion object {

--- a/app/src/main/java/com/example/qstreak/ui/OnboardingSignupFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/OnboardingSignupFragment.kt
@@ -1,6 +1,5 @@
 package com.example.qstreak.ui
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -40,15 +39,13 @@ class OnboardingSignupFragment : Fragment() {
     private fun observeSignup() {
         onboardingViewModel.signupSuccessful.observe(viewLifecycleOwner, Observer {
             if (it) {
-                onSignupSuccess()
+                navigateToFirstSubmission()
             }
         })
     }
 
-    private fun onSignupSuccess() {
-        val intent = Intent(activity, SubmissionsActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(intent)
+    private fun navigateToFirstSubmission() {
+        (activity as OnboardingActivity).setCurrentItem(OnboardingSubmissionFragment.ONBOARDING_ADAPTER_POSITION)
     }
 
     companion object {

--- a/app/src/main/java/com/example/qstreak/ui/OnboardingSubmissionFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/OnboardingSubmissionFragment.kt
@@ -1,0 +1,20 @@
+package com.example.qstreak.ui
+
+import android.content.Intent
+
+class OnboardingSubmissionFragment : AddSubmissionFragment() {
+
+    override fun onSubmissionCompleted() {
+        navigateToDashboard()
+    }
+
+    private fun navigateToDashboard() {
+        val intent = Intent(activity, SubmissionsActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(intent)
+    }
+
+    companion object {
+        const val ONBOARDING_ADAPTER_POSITION = 2
+    }
+}

--- a/app/src/main/java/com/example/qstreak/utils/KoinUtils.kt
+++ b/app/src/main/java/com/example/qstreak/utils/KoinUtils.kt
@@ -9,9 +9,8 @@ import com.example.qstreak.db.SubmissionRepository
 import com.example.qstreak.db.UserRepository
 import com.example.qstreak.network.QstreakApiService
 import com.example.qstreak.network.QstreakApiSignupService
-import com.example.qstreak.ui.OnboardingSignupFragment
-import com.example.qstreak.ui.SplashActivity
-import com.example.qstreak.ui.SubmissionsActivity
+import com.example.qstreak.ui.*
+import com.example.qstreak.viewmodels.AddSubmissionViewModel
 import com.example.qstreak.viewmodels.OnboardingViewModel
 import com.example.qstreak.viewmodels.SplashViewModel
 import com.example.qstreak.viewmodels.SubmissionsViewModel
@@ -69,9 +68,9 @@ private fun databaseModule() = module {
 }
 
 private fun repositoryModule() = module {
-    single { UserRepository(get()) }
-    single { SubmissionRepository(get(), get()) }
-    single { ActivitiesRepository(get()) }
+    single { UserRepository(get(), get()) }
+    single { SubmissionRepository(get(), get(), get()) }
+    single { ActivitiesRepository(get(), get()) }
 }
 
 private fun scopeModules() = module {
@@ -79,9 +78,15 @@ private fun scopeModules() = module {
         viewModel { SplashViewModel(get()) }
     }
     scope(named<SubmissionsActivity>()) {
-        viewModel { SubmissionsViewModel(get(), get(), get()) }
+        viewModel { SubmissionsViewModel(get(), get()) }
     }
     scope(named<OnboardingSignupFragment>()) {
         viewModel { OnboardingViewModel(get(), get()) }
+    }
+    scope(named<AddSubmissionFragment>()) {
+        viewModel { AddSubmissionViewModel(get(), get(), get()) }
+    }
+    scope(named<OnboardingSubmissionFragment>()) {
+        viewModel { AddSubmissionViewModel(get(), get(), get()) }
     }
 }

--- a/app/src/main/java/com/example/qstreak/viewmodels/AddSubmissionViewModel.kt
+++ b/app/src/main/java/com/example/qstreak/viewmodels/AddSubmissionViewModel.kt
@@ -1,0 +1,76 @@
+package com.example.qstreak.viewmodels
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.qstreak.db.ActivitiesRepository
+import com.example.qstreak.db.SubmissionRepository
+import com.example.qstreak.models.Activity
+import com.example.qstreak.models.Submission
+import com.example.qstreak.utils.UID
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class AddSubmissionViewModel(
+    private val submissionRepository: SubmissionRepository,
+    private val activitiesRepository: ActivitiesRepository,
+    sharedPreferences: SharedPreferences
+) : ViewModel() {
+
+    val activities: LiveData<List<Activity>> = activitiesRepository.activities
+    private val checkedActivities = arrayListOf<Activity>()
+
+    val submissionComplete = MutableLiveData<Boolean>(false)
+    val date = MutableLiveData<String>()
+    val contactCount = MutableLiveData<String>()
+
+    val uid: String? by lazy {
+        sharedPreferences.getString(UID, null)
+    }
+
+    fun refreshActivities() {
+        // TODO handle null uid
+        if (uid != null) {
+            viewModelScope.launch {
+                try {
+                    activitiesRepository.refreshActivities(uid as String)
+                } catch (e: Exception) {
+                    Timber.e("Error message: %s", e.message)
+                }
+            }
+        }
+    }
+
+    fun createSubmission() {
+        // TODO handle null uid
+        if (uid != null && isUserInputValid()) {
+            val submission = Submission(date.value!!, contactCount.value!!.toInt())
+            viewModelScope.launch {
+                try {
+                    submissionRepository.insert(submission, checkedActivities, uid as String)
+                    submissionComplete.value = true
+                } catch (e: Exception) {
+                    // TODO retrieve error text from response body to surface to user (at api layer)
+                    Timber.e("Error message: %s", e.message)
+                } finally {
+                    checkedActivities.clear()
+                }
+            }
+        }
+    }
+
+    private fun isUserInputValid(): Boolean {
+        // TODO
+        return true
+    }
+
+    fun onActivityCheckboxToggled(activity: Activity) {
+        if (checkedActivities.contains(activity)) {
+            checkedActivities.remove(activity)
+        } else {
+            checkedActivities.add(activity)
+        }
+    }
+}

--- a/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
+++ b/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
@@ -7,33 +7,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.qstreak.db.ActivitiesRepository
 import com.example.qstreak.db.SubmissionRepository
-import com.example.qstreak.models.Activity
 import com.example.qstreak.models.DailyStats
-import com.example.qstreak.models.Submission
 import com.example.qstreak.models.SubmissionWithActivities
 import com.example.qstreak.utils.UID
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class SubmissionsViewModel(
     private val submissionRepository: SubmissionRepository,
-    private val activitiesRepository: ActivitiesRepository,
     sharedPrefs: SharedPreferences
 ) : ViewModel() {
 
     val submissions: LiveData<List<SubmissionWithActivities>> =
         submissionRepository.submissionsWithWithActivities
-    val activities: LiveData<List<Activity>> = activitiesRepository.activities
 
     val selectedSubmission = MutableLiveData<SubmissionWithActivities>()
     val selectedSubmissionDailyStats = MutableLiveData<DailyStats>()
 
-    private val checkedActivities = arrayListOf<Activity>()
     private val uid: String? = sharedPrefs.getString(UID, null)
-
-    init {
-        refreshActivities()
-    }
 
     fun selectSubmission(submissionWithActivities: SubmissionWithActivities) {
         selectedSubmission.value = submissionWithActivities
@@ -48,43 +38,6 @@ class SubmissionsViewModel(
                 submissionWithActivities.submission.remoteId?.let {
                     val response = submissionRepository.fetchDailyStatsForSubmission(it, uid)
                     selectedSubmissionDailyStats.value = response
-                }
-            }
-        }
-    }
-
-    fun createSubmission(submission: Submission) {
-        // TODO handle null uid
-        if (uid != null) {
-            viewModelScope.launch {
-                try {
-                    submissionRepository.insert(submission, checkedActivities, uid)
-                } catch (e: Exception) {
-                    // TODO retrieve error text from response body to surface to user (at api layer)
-                    Timber.e("Error message: %s", e.message)
-                } finally {
-                    checkedActivities.clear()
-                }
-            }
-        }
-    }
-
-    fun onActivityCheckboxToggled(activity: Activity) {
-        if (checkedActivities.contains(activity)) {
-            checkedActivities.remove(activity)
-        } else {
-            checkedActivities.add(activity)
-        }
-    }
-
-    private fun refreshActivities() {
-        // TODO handle null uid
-        if (uid != null) {
-            viewModelScope.launch {
-                try {
-                    activitiesRepository.refreshActivities(uid)
-                } catch (e: Exception) {
-                    Timber.e("Error message: %s", e.message)
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_add_submission.xml
+++ b/app/src/main/res/layout/fragment_add_submission.xml
@@ -5,8 +5,8 @@
     <data>
 
         <variable
-            name="submissionsViewModel"
-            type="com.example.qstreak.viewmodels.SubmissionsViewModel" />
+            name="viewModel"
+            type="com.example.qstreak.viewmodels.AddSubmissionViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -24,7 +24,8 @@
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:text="@={viewModel.date}" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -39,7 +40,8 @@
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:text="@={viewModel.contactCount}" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -64,10 +66,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="32dp"
+            android:onClick="@{() -> viewModel.createSubmission()}"
             android:text="Save"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>


### PR DESCRIPTION
This PR
* Makes `AddSubmissionFragment` an open class so we can extend it in the onboarding flow with minimal additional code
* Extracts logic for creating a new submission into a separate viewmodel from displaying submissions list and detail
* Further improves use of Koin by injecting apis to repositories