### PR TITLE
Rb/edit existing submission

### DIFF
--- a/app/src/main/java/com/example/qstreak/db/QstreakDatabase.kt
+++ b/app/src/main/java/com/example/qstreak/db/QstreakDatabase.kt
@@ -11,7 +11,7 @@ import com.example.qstreak.models.User
 
 @Database(
     entities = [Submission::class, User::class, Activity::class, SubmissionActivityCrossRef::class],
-    version = 11
+    version = 13
 )
 abstract class QstreakDatabase : RoomDatabase() {
 

--- a/app/src/main/java/com/example/qstreak/db/SubmissionDao.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionDao.kt
@@ -18,6 +18,6 @@ interface SubmissionDao {
     @Update
     suspend fun update(submission: Submission)
 
-    @Delete
-    suspend fun delete(submission: Submission)
+    @Query("DELETE FROM submissions WHERE remote_id = :remoteId")
+    suspend fun deleteByRemoteId(remoteId: Int)
 }

--- a/app/src/main/java/com/example/qstreak/db/SubmissionDao.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionDao.kt
@@ -12,9 +12,6 @@ interface SubmissionDao {
     @Query("SELECT * FROM submissions LIMIT 100")
     fun getAllSubmissions(): LiveData<List<Submission>>
 
-    @Query("SELECT * FROM submissions WHERE submission_id = :id")
-    suspend fun get(id: Int): Submission
-
     @Update
     suspend fun update(submission: Submission)
 

--- a/app/src/main/java/com/example/qstreak/db/SubmissionRepository.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionRepository.kt
@@ -44,8 +44,8 @@ class SubmissionRepository(
         }
     }
 
-    suspend fun getSubmissionById(id: Int): Submission {
-        return submissionDao.get(id)
+    suspend fun getSubmissionWithActivitiesByDate(date: String): SubmissionWithActivities {
+        return submissionWithActivityDao.getByDate(date)
     }
 
     suspend fun fetchDailyStatsForSubmission(remoteId: Int, uid: String): DailyStats {

--- a/app/src/main/java/com/example/qstreak/db/SubmissionWithActivityDao.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionWithActivityDao.kt
@@ -2,8 +2,8 @@ package com.example.qstreak.db
 
 import androidx.lifecycle.LiveData
 import androidx.room.*
-import com.example.qstreak.models.SubmissionWithActivities
 import com.example.qstreak.models.SubmissionActivityCrossRef
+import com.example.qstreak.models.SubmissionWithActivities
 
 @Dao
 interface SubmissionWithActivityDao {
@@ -13,4 +13,8 @@ interface SubmissionWithActivityDao {
     @Transaction
     @Query("SELECT * FROM submissions")
     fun getSubmissionsWithActivities(): LiveData<List<SubmissionWithActivities>>
+
+    @Transaction
+    @Query("SELECT * FROM submissions WHERE date = :date LIMIT 1")
+    suspend fun getByDate(date: String): SubmissionWithActivities
 }

--- a/app/src/main/java/com/example/qstreak/db/SubmissionWithActivityDao.kt
+++ b/app/src/main/java/com/example/qstreak/db/SubmissionWithActivityDao.kt
@@ -16,5 +16,8 @@ interface SubmissionWithActivityDao {
 
     @Transaction
     @Query("SELECT * FROM submissions WHERE date = :date LIMIT 1")
-    suspend fun getByDate(date: String): SubmissionWithActivities
+    suspend fun getSubmissionWithActivitiesByDate(date: String): SubmissionWithActivities
+
+    @Query("DELETE FROM submission_activity_cross_ref WHERE remote_id = :remoteId")
+    suspend fun deleteActivitiesBySubmissionId(remoteId: Int)
 }

--- a/app/src/main/java/com/example/qstreak/models/Submission.kt
+++ b/app/src/main/java/com/example/qstreak/models/Submission.kt
@@ -6,13 +6,8 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "submissions")
 data class Submission(
-    // TODO change primary key to date?
     @ColumnInfo(name = "date") var date: String,
     @ColumnInfo(name = "contact_count") var contactCount: Int,
-    @ColumnInfo(name = "remote_id") var remoteId: Int? = null,
+    @PrimaryKey @ColumnInfo(name = "remote_id") var remoteId: Int,
     @ColumnInfo(name = "score") var score: Int? = null
-) {
-    @PrimaryKey(autoGenerate = true)
-    @ColumnInfo(name = "submission_id")
-    var submissionId: Int = 0
-}
+)

--- a/app/src/main/java/com/example/qstreak/models/Submission.kt
+++ b/app/src/main/java/com/example/qstreak/models/Submission.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "submissions")
 data class Submission(
+    // TODO change primary key to date?
     @ColumnInfo(name = "date") var date: String,
     @ColumnInfo(name = "contact_count") var contactCount: Int,
     @ColumnInfo(name = "remote_id") var remoteId: Int? = null,

--- a/app/src/main/java/com/example/qstreak/models/SubmissionActivityCrossRef.kt
+++ b/app/src/main/java/com/example/qstreak/models/SubmissionActivityCrossRef.kt
@@ -3,8 +3,11 @@ package com.example.qstreak.models
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 
-@Entity(primaryKeys = ["submission_id", "activity_slug"])
+@Entity(
+    tableName = "submission_activity_cross_ref",
+    primaryKeys = ["remote_id", "activity_slug"]
+)
 data class SubmissionActivityCrossRef(
-    @ColumnInfo(name = "submission_id") val submissionId: Int,
+    @ColumnInfo(name = "remote_id") val remoteId: Int,
     @ColumnInfo(name = "activity_slug") val activitySlug: String
 )

--- a/app/src/main/java/com/example/qstreak/models/SubmissionWithActivities.kt
+++ b/app/src/main/java/com/example/qstreak/models/SubmissionWithActivities.kt
@@ -8,12 +8,12 @@ data class SubmissionWithActivities(
     @Embedded
     var submission: Submission,
     @Relation(
-        parentColumn = "submission_id",
+        parentColumn = "remote_id",
         entity = Activity::class,
         entityColumn = "activity_slug",
         associateBy = Junction(
             value = SubmissionActivityCrossRef::class,
-            parentColumn = "submission_id",
+            parentColumn = "remote_id",
             entityColumn = "activity_slug"
         )
     )

--- a/app/src/main/java/com/example/qstreak/network/QstreakApiService.kt
+++ b/app/src/main/java/com/example/qstreak/network/QstreakApiService.kt
@@ -32,6 +32,13 @@ interface QstreakApiService {
         @Header(AUTHORIZATION) uid: String
     ): Response<Unit>
 
+    @PUT("submissions/{remoteId}")
+    suspend fun updateSubmission(
+        @Path("remoteId") remoteId: Int,
+        @Body updateSubmissionRequest: UpdateSubmissionRequest,
+        @Header(AUTHORIZATION) uid: String
+    ): SubmissionResponse
+
     companion object {
         const val AUTHORIZATION = "Authorization"
 

--- a/app/src/main/java/com/example/qstreak/network/SubmissionResponse.kt
+++ b/app/src/main/java/com/example/qstreak/network/SubmissionResponse.kt
@@ -2,6 +2,7 @@ package com.example.qstreak.network
 
 import com.example.qstreak.models.Activity
 import com.example.qstreak.models.DailyStats
+import com.example.qstreak.models.Submission
 import com.squareup.moshi.Json
 
 data class SubmissionResponse(
@@ -11,4 +12,8 @@ data class SubmissionResponse(
     @field:Json(name = "id") val id: Int,
     @field:Json(name = "daily_stats") val dailyStats: DailyStats,
     @field:Json(name = "score") val score: Int
-)
+) {
+    fun toLocalSubmission(): Submission {
+        return Submission(date, contactCount, id, score)
+    }
+}

--- a/app/src/main/java/com/example/qstreak/network/UpdateSubmissionRequest.kt
+++ b/app/src/main/java/com/example/qstreak/network/UpdateSubmissionRequest.kt
@@ -1,0 +1,12 @@
+package com.example.qstreak.network
+
+import com.squareup.moshi.Json
+
+data class UpdateSubmissionRequest(
+    @field:Json(name = "submission") val updateSubmissionData: UpdateSubmissionData
+)
+
+data class UpdateSubmissionData(
+    @field:Json(name = "contact_count") val contactCount: Int,
+    @field:Json(name = "destination_slugs") val activitySlugs: List<String>
+)

--- a/app/src/main/java/com/example/qstreak/ui/ActivitiesChecklistAdapter.kt
+++ b/app/src/main/java/com/example/qstreak/ui/ActivitiesChecklistAdapter.kt
@@ -20,6 +20,8 @@ class ActivitiesChecklistAdapter(
         this.addAll(activities)
     }
 
+    private val checkedActivities = mutableListOf<Activity>()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActivityViewHolder {
         val holder = ActivityViewHolder(
             LayoutInflater.from(parent.context).inflate(
@@ -30,7 +32,6 @@ class ActivitiesChecklistAdapter(
         )
 
         holder.itemView.setOnClickListener {
-            holder.checkBox.toggle()
             onItemClicked(activities[holder.adapterPosition])
         }
 
@@ -44,6 +45,13 @@ class ActivitiesChecklistAdapter(
     override fun onBindViewHolder(holder: ActivityViewHolder, position: Int) {
         val activity = activities[position]
         holder.activityName.text = activity.name
+        holder.checkBox.isChecked = checkedActivities.contains(activity)
+    }
+
+    fun setCheckedActivities(activities: List<Activity>) {
+        checkedActivities.clear()
+        checkedActivities.addAll(activities)
+        notifyDataSetChanged()
     }
 
     inner class ActivityViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -51,6 +52,7 @@ class AddEditSubmissionFragment : Fragment() {
         setupActivitiesList()
         observeExistingSubmission()
         observeCompletion()
+        observeErrors()
         setDateClickListener()
 
         return binding.root
@@ -93,6 +95,12 @@ class AddEditSubmissionFragment : Fragment() {
             if (it) {
                 onSubmissionCompleted()
             }
+        })
+    }
+
+    private fun observeErrors() {
+        addEditViewModel.errorToDisplay.observe(viewLifecycleOwner, Observer {
+            Toast.makeText(requireContext(), it, Toast.LENGTH_LONG).show()
         })
     }
 

--- a/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
@@ -108,6 +108,7 @@ class AddEditSubmissionFragment : Fragment() {
         binding.dateButton.setOnClickListener {
             val builder = MaterialDatePicker.Builder.datePicker()
             val picker = builder.build()
+            // TODO listen for user changing date with date picker, then check to see if there is an existing record for that date (need to handle time zone weirdness)
             picker.addOnPositiveButtonClickListener {
                 // Log.d("DatePicker Activity", "Date String = ${picker.headerText}:: Date epoch value = ${it}")
                 val pickedDate = Date(it)

--- a/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.qstreak.R
-import com.example.qstreak.databinding.FragmentAddSubmissionBinding
+import com.example.qstreak.databinding.FragmentAddEditSubmissionBinding
 import com.example.qstreak.models.Activity
 import com.example.qstreak.viewmodels.AddEditSubmissionViewModel
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -23,7 +23,7 @@ class AddEditSubmissionFragment : Fragment() {
     private val addEditViewModel: AddEditSubmissionViewModel by currentScope.viewModel(this)
     private val dateFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
-    private lateinit var binding: FragmentAddSubmissionBinding
+    private lateinit var binding: FragmentAddEditSubmissionBinding
 
     override fun onResume() {
         super.onResume()
@@ -41,7 +41,7 @@ class AddEditSubmissionFragment : Fragment() {
 
         binding = DataBindingUtil.inflate(
             LayoutInflater.from(activity),
-            R.layout.fragment_add_submission,
+            R.layout.fragment_add_edit_submission,
             null,
             false
         )

--- a/app/src/main/java/com/example/qstreak/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/qstreak/ui/MainActivity.kt
@@ -26,11 +26,9 @@ class MainActivity : FragmentActivity(R.layout.activity_main) {
             .replace(R.id.fragment_container_view, fragment)
             .commit()
     }
-
-    // TODO: We'll pass an optional submission ID through fragment bundle
-    // to determine whether to fetch existing submission data.
-    fun navigateToAddOrEditRecord() {
-        val fragment = AddEditSubmissionFragment()
+    
+    fun navigateToAddOrEditRecord(existingSubmissionDate: String? = null) {
+        val fragment = AddEditSubmissionFragment.newInstance(existingSubmissionDate)
         supportFragmentManager.beginTransaction()
             .addToBackStack(AddEditSubmissionFragment.TAG)
             .replace(R.id.fragment_container_view, fragment)

--- a/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
@@ -31,9 +31,18 @@ class SubmissionDetailFragment : Fragment() {
         binding.lifecycleOwner = activity
         binding.viewModel = submissionsViewModel
 
+        setupEditClickListener()
         observeDeletion()
 
         return binding.root
+    }
+
+    private fun setupEditClickListener() {
+        binding.editButton.setOnClickListener {
+            (requireActivity() as MainActivity).navigateToAddOrEditRecord(
+                submissionsViewModel.selectedSubmission.value?.submission?.date
+            )
+        }
     }
 
     private fun observeDeletion() {

--- a/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
@@ -17,6 +17,11 @@ class SubmissionDetailFragment : Fragment() {
     }
     private lateinit var binding: FragmentSubmissionDetailBinding
 
+    override fun onResume() {
+        super.onResume()
+        submissionsViewModel.refreshSelectedSubmission()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/example/qstreak/utils/KoinUtils.kt
+++ b/app/src/main/java/com/example/qstreak/utils/KoinUtils.kt
@@ -96,7 +96,7 @@ private fun scopeModules() = module {
         viewModel { OnboardingViewModel(get(), get()) }
     }
     scope(named<AddEditSubmissionFragment>()) {
-        viewModel { AddSubmissionViewModel(get(), get(), get()) }
+        viewModel { AddEditSubmissionViewModel(get(), get(), get()) }
     }
     scope(named<DashboardFragment>()) {
         viewModel { DashboardViewModel() }

--- a/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
+++ b/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
@@ -17,7 +17,7 @@ class SubmissionsViewModel(
 ) : ViewModel() {
 
     val submissions: LiveData<List<SubmissionWithActivities>> =
-        submissionRepository.submissionsWithWithActivities
+        submissionRepository.submissionsWithActivities
 
     val selectedSubmission = MutableLiveData<SubmissionWithActivities>()
     val selectedSubmissionDailyStats = MutableLiveData<DailyStats>()
@@ -29,6 +29,16 @@ class SubmissionsViewModel(
         selectedSubmission.value = submissionWithActivities
         selectedSubmissionDailyStats.value = null
         populateDailyStats(submissionWithActivities)
+    }
+
+    fun refreshSelectedSubmission() {
+        val selectedDate = selectedSubmission.value?.submission?.date
+        selectedDate?.let {
+            viewModelScope.launch {
+                selectedSubmission.value =
+                    submissionRepository.getSubmissionWithActivitiesByDate(selectedDate)
+            }
+        }
     }
 
     fun deleteSubmission() {

--- a/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
+++ b/app/src/main/java/com/example/qstreak/viewmodels/SubmissionsViewModel.kt
@@ -44,7 +44,7 @@ class SubmissionsViewModel(
     fun deleteSubmission() {
         if (uid != null) {
             viewModelScope.launch {
-                submissionRepository.delete(selectedSubmission.value!!.submission, uid)
+                submissionRepository.deleteSubmission(selectedSubmission.value!!.submission, uid)
                 // TODO this is a case for SingleLiveEvent
                 submissionDeleted.value = true
             }
@@ -55,10 +55,11 @@ class SubmissionsViewModel(
         // TODO handle null uid
         if (uid != null) {
             viewModelScope.launch {
-                submissionWithActivities.submission.remoteId?.let {
-                    val response = submissionRepository.fetchDailyStatsForSubmission(it, uid)
-                    selectedSubmissionDailyStats.value = response
-                }
+                val response = submissionRepository.fetchDailyStatsForSubmission(
+                    submissionWithActivities.submission.remoteId,
+                    uid
+                )
+                selectedSubmissionDailyStats.value = response
             }
         }
     }

--- a/app/src/main/res/layout/fragment_add_edit_submission.xml
+++ b/app/src/main/res/layout/fragment_add_edit_submission.xml
@@ -65,7 +65,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="32dp"
-            android:onClick="@{() -> viewModel.createSubmission()}"
+            android:onClick="@{() -> viewModel.saveSubmission()}"
             android:text="Save"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_add_submission.xml
+++ b/app/src/main/res/layout/fragment_add_submission.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="viewModel"
-            type="com.example.qstreak.viewmodels.AddSubmissionViewModel" />
+            type="com.example.qstreak.viewmodels.AddEditSubmissionViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_submission_detail.xml
+++ b/app/src/main/res/layout/fragment_submission_detail.xml
@@ -109,16 +109,26 @@
             app:layout_constraintTop_toBottomOf="@id/submission_detail_deaths"
             tools:text="Risk level: 4" />
 
-        <ImageView
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/edit_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="Edit"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/submission_detail_risk_level" />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/delete_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:contentDescription="@string/delete_submission"
             android:onClick="@{() -> viewModel.deleteSubmission()}"
-            android:src="@android:drawable/ic_delete"
+            android:text="Delete Record"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/submission_detail_risk_level" />
+            app:layout_constraintTop_toBottomOf="@id/edit_button" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
This PR is on the big side. Here's what it does:
* Adds an Edit button to the detail page. When tapped, loads the existing Add Record screen but with data for the detail page's submission pre-populated.
* Allows user to save an update to an existing submission's contact count or destinations.
* Refactors the `Submission` data model to use `remoteId` as the primary key. This model now isn't employed until the server confirms a remote id for us.

NB there is an issue with the date populated from an existing record that appears to be timezone-related (picker is pre-populated with the prior day at midnight when editing an existing record). In addition, functionality needs to be added to query the db for an existing record when the user changes the date.