### PR TITLE
Rb/fix date issues

### DIFF
--- a/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/AddEditSubmissionFragment.kt
@@ -14,15 +14,18 @@ import com.example.qstreak.databinding.FragmentAddEditSubmissionBinding
 import com.example.qstreak.models.Activity
 import com.example.qstreak.utils.DateUtils
 import com.example.qstreak.viewmodels.AddEditSubmissionViewModel
+import com.example.qstreak.viewmodels.SubmissionsViewModel
 import com.google.android.material.datepicker.MaterialDatePicker
 import org.koin.androidx.scope.currentScope
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import java.text.SimpleDateFormat
 import java.util.*
 
 class AddEditSubmissionFragment : Fragment() {
 
     private val addEditViewModel: AddEditSubmissionViewModel by currentScope.viewModel(this)
+    private val submissionsViewModel: SubmissionsViewModel by lazy {
+        (requireActivity() as MainActivity).submissionsViewModel
+    }
 
     private lateinit var binding: FragmentAddEditSubmissionBinding
 
@@ -36,8 +39,8 @@ class AddEditSubmissionFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        arguments?.getString(SUBMISSION_DATE_KEY)?.let {
-            addEditViewModel.initializeWithDate(it)
+        arguments?.getString(DATE_STRING)?.let {
+            addEditViewModel.loadDate(it)
         }
 
         binding = DataBindingUtil.inflate(
@@ -50,9 +53,9 @@ class AddEditSubmissionFragment : Fragment() {
         binding.viewModel = addEditViewModel
 
         setupActivitiesList()
-        observeExistingSubmission()
         observeCompletion()
         observeErrors()
+        observeSelectedDateChange()
         setDateClickListener()
 
         return binding.root
@@ -75,31 +78,11 @@ class AddEditSubmissionFragment : Fragment() {
 
         // Update UI with activities currently checked
         addEditViewModel.checkedActivities.observe(viewLifecycleOwner, Observer {
-            adapter.setCheckedActivities(it.orEmpty())
+            adapter.setCheckedActivities(it)
         })
 
         binding.activitiesChecklist.adapter = adapter
         binding.activitiesChecklist.layoutManager = LinearLayoutManager(activity)
-    }
-
-    // TODO this is MVP. How to avoid coming back up to the Fragment here?
-    private fun observeExistingSubmission() {
-        addEditViewModel.existingSubmission.observe(viewLifecycleOwner, Observer { existing ->
-            if (existing != null) {
-                // TODO less gross way to do this: (ensures if we return to detail page the correct record is selected)
-                (requireActivity() as MainActivity).submissionsViewModel.selectSubmission(existing)
-
-                addEditViewModel.contactCount.value = existing.submission.contactCount.toString()
-                addEditViewModel.submissionDate.value =
-                    DateUtils.getDateFromDbRecord(existing.submission.date)
-                addEditViewModel.submissionDateString.value =
-                    DateUtils.getDateStringForAddEditFromDbRecord(existing.submission.date)
-                addEditViewModel.checkedActivities.value = existing.activities
-            } else {
-                addEditViewModel.contactCount.value = null
-                addEditViewModel.checkedActivities.value = null
-            }
-        })
     }
 
     private fun observeCompletion() {
@@ -116,6 +99,13 @@ class AddEditSubmissionFragment : Fragment() {
         })
     }
 
+    private fun observeSelectedDateChange() {
+        // TODO not proper MVVM?
+        addEditViewModel.selectedDateString.observe(viewLifecycleOwner, Observer {
+            submissionsViewModel.selectDate(it)
+        })
+    }
+
     private fun setDateClickListener() {
         binding.dateButton.setOnClickListener {
             val builder = MaterialDatePicker.Builder.datePicker()
@@ -127,7 +117,7 @@ class AddEditSubmissionFragment : Fragment() {
                     this.add(Calendar.DATE, 1)
                 }
                 val pickedDate = DateUtils.dateStringFormat.format(calendar.time)
-                addEditViewModel.initializeWithDate(pickedDate)
+                addEditViewModel.loadDate(pickedDate)
             }
             picker.show(requireActivity().supportFragmentManager, picker.toString())
         }
@@ -139,13 +129,11 @@ class AddEditSubmissionFragment : Fragment() {
 
     companion object {
         const val TAG = "AddSubmissionFragment"
-        const val SUBMISSION_DATE_KEY = "submission_id"
+        private const val DATE_STRING = "date_string"
 
-        fun newInstance(existingSubmissionDate: String?): AddEditSubmissionFragment {
+        fun newInstance(dateString: String): AddEditSubmissionFragment {
             val fragment = AddEditSubmissionFragment()
-            existingSubmissionDate?.let { date ->
-                fragment.arguments = Bundle().apply { this.putString(SUBMISSION_DATE_KEY, date) }
-            }
+            fragment.arguments = Bundle().apply { this.putString(DATE_STRING, dateString) }
             return fragment
         }
     }

--- a/app/src/main/java/com/example/qstreak/ui/DashboardFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/DashboardFragment.kt
@@ -79,7 +79,7 @@ class DashboardFragment : Fragment() {
 
     private fun onDailyLogItemSelected(item: DailyLogItemInfo) {
         if (item.isComplete) {
-            submissionsViewModel.selectSubmission(item.submission!!)
+            submissionsViewModel.selectDate(DateUtils.dateStringFormat.format(item.date))
             (requireActivity() as MainActivity).navigateToShowRecord()
         } else {
             (requireActivity() as MainActivity).navigateToAddOrEditRecord(

--- a/app/src/main/java/com/example/qstreak/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/qstreak/ui/MainActivity.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import com.example.qstreak.R
+import com.example.qstreak.utils.DateUtils
 import com.example.qstreak.viewmodels.SubmissionsViewModel
 import org.koin.androidx.scope.currentScope
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.util.*
 
 class MainActivity : FragmentActivity(R.layout.activity_main) {
     val submissionsViewModel: SubmissionsViewModel by currentScope.viewModel(this)
@@ -22,14 +24,18 @@ class MainActivity : FragmentActivity(R.layout.activity_main) {
     }
 
     fun navigateToShowRecord() {
-        val fragment = SubmissionDetailFragment()
+        val fragment = SubmissionDetailFragment.newInstance()
         supportFragmentManager.beginTransaction()
             .addToBackStack(SubmissionDetailFragment.TAG)
             .replace(R.id.fragment_container_view, fragment)
             .commit()
     }
 
-    fun navigateToAddOrEditRecord(existingSubmissionDate: String? = null) {
+    fun navigateToAddOrEditRecord(
+        existingSubmissionDate: String = DateUtils.dateStringFormat.format(
+            Calendar.getInstance().time
+        )
+    ) {
         val fragment = AddEditSubmissionFragment.newInstance(existingSubmissionDate)
         supportFragmentManager.beginTransaction()
             .addToBackStack(AddEditSubmissionFragment.TAG)

--- a/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
+++ b/app/src/main/java/com/example/qstreak/ui/SubmissionDetailFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.qstreak.R
 import com.example.qstreak.databinding.FragmentSubmissionDetailBinding
+import com.example.qstreak.utils.DateUtils
 import com.example.qstreak.viewmodels.SubmissionsViewModel
 
 class SubmissionDetailFragment : Fragment() {
@@ -20,7 +21,7 @@ class SubmissionDetailFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        submissionsViewModel.refreshSelectedSubmission()
+        submissionsViewModel.refreshDate()
     }
 
     override fun onCreateView(
@@ -38,6 +39,7 @@ class SubmissionDetailFragment : Fragment() {
         binding.viewModel = submissionsViewModel
 
         setupEditClickListener()
+        observeDate()
         observeDeletion()
         setupActivitiesList()
 
@@ -46,10 +48,19 @@ class SubmissionDetailFragment : Fragment() {
 
     private fun setupEditClickListener() {
         binding.editButton.setOnClickListener {
-            (requireActivity() as MainActivity).navigateToAddOrEditRecord(
-                submissionsViewModel.selectedSubmission.value?.submission?.date
-            )
+            submissionsViewModel.selectedDateString.value?.let {
+                (requireActivity() as MainActivity).navigateToAddOrEditRecord(it)
+            } ?: run {
+                (requireActivity() as MainActivity).navigateToAddOrEditRecord()
+            }
+
         }
+    }
+
+    private fun observeDate() {
+        submissionsViewModel.selectedDateString.observe(viewLifecycleOwner, Observer {
+            binding.submissionDetailDate.text = DateUtils.getDateDisplayStringFromDbRecord(it)
+        })
     }
 
     private fun observeDeletion() {
@@ -78,5 +89,9 @@ class SubmissionDetailFragment : Fragment() {
 
     companion object {
         const val TAG = "SubmissionDetailFragment"
+
+        fun newInstance(): SubmissionDetailFragment {
+            return SubmissionDetailFragment()
+        }
     }
 }

--- a/app/src/main/java/com/example/qstreak/utils/DateUtils.kt
+++ b/app/src/main/java/com/example/qstreak/utils/DateUtils.kt
@@ -38,11 +38,11 @@ object DateUtils {
         return dateFormatWeekOfDate.format(calendar.time)
     }
 
-    fun getDateStringForAddEditFromDate(date: Date = Calendar.getInstance().time): String {
+    fun getDateDisplayStringFromDate(date: Date = Calendar.getInstance().time): String {
         return dateStringFormatForAddEditRecord.format(date)
     }
 
-    fun getDateStringForAddEditFromDbRecord(dbString: String): String? {
+    fun getDateDisplayStringFromDbRecord(dbString: String): String? {
         return getDateFromDbRecord(dbString)?.let {
             dateStringFormatForAddEditRecord.format(it)
         }

--- a/app/src/main/java/com/example/qstreak/viewmodels/AddEditSubmissionViewModel.kt
+++ b/app/src/main/java/com/example/qstreak/viewmodels/AddEditSubmissionViewModel.kt
@@ -15,7 +15,6 @@ import com.example.qstreak.utils.DateUtils
 import com.example.qstreak.utils.UID
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.math.max
 
@@ -25,18 +24,23 @@ class AddEditSubmissionViewModel(
     sharedPreferences: SharedPreferences
 ) : ViewModel() {
 
-    // TODO is this locale okay to use?
-    private val dateFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-
+    // Used in display of Add/Edit Record screen
     val activities: LiveData<List<Activity>> = activitiesRepository.activities
-    val checkedActivities = MutableLiveData<List<Activity>>()
-
-    val submissionComplete = MutableLiveData<Boolean>(false)
-    val submissionDate = MutableLiveData<Date>(Date())
-    val submissionDateString = MutableLiveData<String>(DateUtils.getDateStringForAddEditFromDate())
+    val checkedActivities = MutableLiveData<List<Activity>>(emptyList())
+    val selectedDateDisplayString =
+        MutableLiveData<String>(DateUtils.getDateDisplayStringFromDate())
     val contactCount = MutableLiveData<String>()
-    val existingSubmission = MutableLiveData<SubmissionWithActivities>()
     val errorToDisplay = MutableLiveData<String>()
+
+    // Observe for when to close add/edit screen
+    val submissionComplete = MutableLiveData<Boolean>(false)
+
+    // Observe for updating selection in other screens
+    val selectedDateString =
+        MutableLiveData<String>(DateUtils.dateStringFormat.format(Calendar.getInstance().time))
+
+    // Observe whether currently selected date has data
+    private val existingSubmission = MutableLiveData<SubmissionWithActivities?>()
 
     private val uid: String? by lazy {
         sharedPreferences.getString(UID, null)
@@ -55,17 +59,25 @@ class AddEditSubmissionViewModel(
         }
     }
 
-    fun initializeWithDate(dateString: String) {
+    fun loadDate(dateString: String) {
         viewModelScope.launch {
             try {
                 val submission = submissionRepository.getSubmissionWithActivitiesByDate(dateString)
                 existingSubmission.value = submission
+                selectedDateString.value = dateString
+                selectedDateDisplayString.value =
+                    DateUtils.getDateDisplayStringFromDbRecord(dateString)
+                if (submission != null) {
+                    contactCount.value = submission.submission.contactCount.toString()
+                    checkedActivities.value = submission.activities
+                } else {
+                    contactCount.value = "0"
+                    checkedActivities.value = emptyList()
+                }
             } catch (e: Exception) {
                 errorToDisplay.value = ("Error loading date: $dateString")
                 Timber.e(e)
             }
-            submissionDate.value = DateUtils.dateStringFormat.parse(dateString)
-            submissionDateString.value = DateUtils.getDateStringForAddEditFromDbRecord(dateString)
         }
     }
 
@@ -86,14 +98,14 @@ class AddEditSubmissionViewModel(
                 viewModelScope.launch {
                     val response = existingSubmission.value?.let {
                         updateExistingSubmission(
-                            it.submission.date,
+                            selectedDateString.value!!,
                             contactCount.value!!.toInt(),
                             checkedActivities.value.orEmpty(),
                             uid as String
                         )
                     } ?: createNewSubmission(
                         contactCount.value!!.toInt(),
-                        dateFormatter.format(submissionDate.value!!),
+                        selectedDateString.value!!,
                         checkedActivities.value.orEmpty(),
                         uid as String
                     )

--- a/app/src/main/res/layout/fragment_add_edit_submission.xml
+++ b/app/src/main/res/layout/fragment_add_edit_submission.xml
@@ -23,7 +23,7 @@
             android:layout_marginTop="32dp"
             android:background="@android:color/transparent"
             android:backgroundTint="@android:color/white"
-            android:text="@{viewModel.submissionDateString}"
+            android:text="@{viewModel.selectedDateDisplayString}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/fragment_submission_detail.xml
+++ b/app/src/main/res/layout/fragment_submission_detail.xml
@@ -10,8 +10,6 @@
             type="com.example.qstreak.viewmodels.SubmissionsViewModel" />
 
         <import type="android.view.View" />
-
-        <import type="com.example.qstreak.utils.DateUtils" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_submission_detail.xml
+++ b/app/src/main/res/layout/fragment_submission_detail.xml
@@ -10,6 +10,8 @@
             type="com.example.qstreak.viewmodels.SubmissionsViewModel" />
 
         <import type="android.view.View" />
+
+        <import type="com.example.qstreak.utils.DateUtils" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -23,7 +25,6 @@
             style="@style/SecondaryHeader"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@{viewModel.selectedSubmission.submission.date}"
             android:textAlignment="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
This PR addresses issue #55, #59, and #43 - changes a few key things about how the viewmodels work together to keep track of the selected date so that if you change the date while editing and return to the detail view, the information has updated. It also fixes the date format on the Show page.

This should wait until after the contact count buttons merge, I'll resolve any merge conflicts first.