### PR TITLE
Add product flavors to allow debug builds with production server

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,15 +13,24 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+        flavorDimensions "default"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        buildConfigField "String", "BASE_URL", '"http://10.0.2.2:4000/"'
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    productFlavors {
+        local {
+            buildConfigField "String", "BASE_URL", '"http://10.0.2.2:4000/"'
+        }
+
+        prod {
+            buildConfigField "String", "BASE_URL", '"https://api.qstreak.com/"'
         }
     }
 


### PR DESCRIPTION
Select "prodDebug" build variant to run a debug version of the app against the production server.